### PR TITLE
Added case study about binary hardening in IoT firmware

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,7 @@ s](http://www.s3.eurecom.fr/docs/usenixsec14_costin.pdf)
 
 ## Case Studies
 
+- [Binary Hardening in IoT products](https://cyber-itl.org/2019/08/26/iot-data-writeup.html)
 - [Hacking the DSP-W215, Again](http://www.devttys0.com/2014/05/hacking-the-dspw215-again/)
 - [Multiple vulnerabilities found in the D-link DWR-932B](https://pierrekim.github.io/blog/2016-09-28-dlink-dwr-932b-lte-routers-vulnerabilities.html)
 - [Pwning the Dlink 850L routers and abusing the MyDlink Cloud protocol](https://pierrekim.github.io/blog/2017-09-08-dlink-850l-mydlink-cloud-0days-vulnerabilities.html)


### PR DESCRIPTION
Added blog article (which also includes the corresponding talk @ ShmooCon 2019) about binary hardening in IoT products. A case study about *"3,333,411 Binaries from 1,294 products of 22 vendors"*.